### PR TITLE
use this.logger.error instead of console.error

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -94,11 +94,11 @@ class Server extends EventEmitter {
         // handle specific listen errors with friendly messages
         switch (error.code) {
             case 'EACCES':
-                console.error(bind + ' requires elevated privileges');
+                this.logger.error(bind + ' requires elevated privileges');
                 process.exit(1);
                 break;
             case 'EADDRINUSE':
-                console.error(bind + ' is already in use');
+                this.logger.error(bind + ' is already in use');
                 process.exit(1);
                 break;
             default:


### PR DESCRIPTION
This closes #7 by using `this.logger.error` instead of `console.error` in `onError`