### PR TITLE
Fix #53 by wrapping init in resolve with deps

### DIFF
--- a/lib/initializeSubapp.js
+++ b/lib/initializeSubapp.js
@@ -23,45 +23,48 @@ module.exports = function $initializeSubappWrapper(App, subappId) {
         if(!config.logger) config.logger = logger;
 
         logger.warn('%s module initialize', subappId);
+        
+        context.resolve(config.dependencies).then(() => { 
+            
+            context.on('server.pre', (configurator) => {
 
-        context.on('server.pre', (configurator) => {
-
-            logger.info('%s server.pre hook...', subappId);
-
-            /*
-             * Ensure we have all required values.
-             * We try to infer if missing.
-             */
-            configurator.addDefaults(config);
-
-            logger.info('%s mounting application. Mount path: %s', subappId, config.mount);
-
-            /*
-             * Right now, App.init will mount middlware.
-             * We should remove it from defaultApp and
-             * have it go through configurator or setup.
-             */
-            let subapp;
-
-            try {
-                subapp = App.init(context, config);
-            } catch(err) {
-                logger.error('Error initializing sub application %s.', subappId);
-                throw err;
-            }
-
-            //@TODO: Can we move this to configurator?!
-            subapp.set('appId', subappId);
-
-            // configurator.middlware(subapp, config);
-
-            /*
-             * We just need to register our routes folder by
-             * adding them to the configuration option
-             * `routesPath`. Those will get autoloaded
-             * by the server module.
-             */
-            configurator.mount(config.mount, subapp);
+                logger.info('%s server.pre hook...', subappId);
+    
+                /*
+                 * Ensure we have all required values.
+                 * We try to infer if missing.
+                 */
+                configurator.addDefaults(config);
+    
+                logger.info('%s mounting application. Mount path: %s', subappId, config.mount);
+    
+                /*
+                 * Right now, App.init will mount middlware.
+                 * We should remove it from defaultApp and
+                 * have it go through configurator or setup.
+                 */
+                let subapp;
+    
+                try {
+                    subapp = App.init(context, config);
+                } catch(err) {
+                    logger.error('Error initializing sub application %s.', subappId);
+                    throw err;
+                }
+    
+                //@TODO: Can we move this to configurator?!
+                subapp.set('appId', subappId);
+    
+                // configurator.middlware(subapp, config);
+    
+                /*
+                 * We just need to register our routes folder by
+                 * adding them to the configuration option
+                 * `routesPath`. Those will get autoloaded
+                 * by the server module.
+                 */
+                configurator.mount(config.mount, subapp);
+            });
         });
     };
 };


### PR DESCRIPTION
This closes #53.

We take any dependencies declared in the config object and we resolve them. 
Now we can do the following:

* **config/my-app.js**:
```js
module.exports = {
  dependencies: ['persistence']
};
```