### PR TITLE
Fix middleware not being overriden by config options;

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2,6 +2,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const extend = require('gextend');
 const express = require('express');
 const getView = require('./getView');
 
@@ -104,7 +105,13 @@ class Setup {
             }
         }
 
+        /**
+         * TODO: We should use the same process as for registering a
+         * default sub app
+         */
         let middleware = require('./middleware');
+        middleware = extend({}, middleware, config.middleware);
+
         let use = [
             'poweredBy',
             'compression',
@@ -125,6 +132,11 @@ class Setup {
             'locals',
             'fileUpload'
         ];
+
+        if(config.middleware.use) {
+            use = config.middleware.use;
+        }
+
         use.map((id)=> {
             middleware[id](app, config);
         });


### PR DESCRIPTION
This closes #55 by ensuring we extend our initial set of middleware with what we get form config options.

We also respect the `config.server.middleware.use` array to change what we use and in what order.